### PR TITLE
Added MoveIndex and Length functions. Updated unit tests and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ Invoke **Permutator.Index()** to return the index of last permutation, which sta
 ```Go
   func (p *Permutator) Reset()
 ```
+  Invoke **Permutator.MoveIndex()** to move the current index position of the permutator
+```Go
+  func (p *Permutator) MoveIndex(index int) (int, error)
+```
+If successful, the integer value of the new index position is returned. If an error occurs, an error is return and the index position will not be adjusted.
+
 An example:
 ```Go
 	func main() {

--- a/components_test.go
+++ b/components_test.go
@@ -54,7 +54,7 @@ func TestFactorial1(t *testing.T) {
 	for _, test := range tests {
 		if result := factorial(test.In); result != test.Result {
 			t.Errorf("%s: result %d doesn't match expected result %d\n",
-				result, test.Result)
+				test.Name, result, test.Result)
 		}
 	}
 }

--- a/permutation.go
+++ b/permutation.go
@@ -11,6 +11,7 @@ var (
 	NotASliceError         = errors.New("argument must be a slice")
 	InvalidCollectionError = errors.New("argument must not be nil")
 	EmptyCollectionError   = errors.New("argument must not be empty")
+	IndexOutOfRangeError   = errors.New("the index is out of range")
 )
 
 type sortable struct {
@@ -90,6 +91,18 @@ func (p *Permutator) Index() int {
 
 	j := p.index - 1
 	return j
+}
+
+// MoveIndex adjusts the current position of the index to the value provided. An error will be returned if the index is invalid or beyond
+// the range of the index of the last permuation
+func (p *Permutator) MoveIndex(index int) (int, error) {
+	if (index > p.length) || (index < 0) {
+		return p.Index(), IndexOutOfRangeError
+	}
+	p.Lock()
+	p.index = index
+	p.Unlock()
+	return p.index, nil
 }
 
 // ErrUnordered occurs when you have a slice in an unordered state

--- a/permutation_test.go
+++ b/permutation_test.go
@@ -289,3 +289,33 @@ func TestCustomLess(t *testing.T) {
 		i++
 	}
 }
+
+func Test_MoveIndex(t *testing.T) {
+	testintdata := []int{1, 2, 3, 4}
+
+	p, err := NewPerm(testintdata, nil)
+	if err != nil {
+		t.Errorf("Error creating permutator: '%s'\n", err)
+	}
+
+	newindex, err := p.MoveIndex(2)
+	if err != nil {
+		t.Errorf("Error moving index: '%s'\n", err)
+	}
+
+	if newindex != 2 {
+		t.Errorf("Expected indext 2, is: %d\n", newindex)
+	}
+
+	// Test that an error occurs if we go beyond the end of the index
+	newindex, err = p.MoveIndex(len(testintdata) + 1)
+	if err == nil {
+		t.Error("Expected an error moving index beyond end of permutations")
+	}
+
+	// Test that an error occurs if we specify a negative index
+	newindex, err = p.MoveIndex(-1)
+	if err == nil {
+		t.Error("Expected an error moving index negative")
+	}
+}

--- a/permutation_test.go
+++ b/permutation_test.go
@@ -139,6 +139,7 @@ func TestPermCustomType0(t *testing.T) {
 	}
 	runTestGeneric(a, e, nil)
 }
+
 func runTestGeneric(a interface{}, e interface{}, l Less) {
 	p, err := NewPerm(a, l)
 	if err != nil {
@@ -302,20 +303,67 @@ func Test_MoveIndex(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error moving index: '%s'\n", err)
 	}
-
 	if newindex != 2 {
 		t.Errorf("Expected indext 2, is: %d\n", newindex)
 	}
 
 	// Test that an error occurs if we go beyond the end of the index
-	newindex, err = p.MoveIndex(len(testintdata) + 1)
+	newindex, err = p.MoveIndex(p.Amount())
+	if err != nil {
+		t.Error("Error moving index to last permutation")
+	}
+	if newindex != p.Amount() {
+		t.Errorf("Expected index %d, was: %d\n", p.Amount(), newindex)
+	}
+
+	// Test that an error occurs if we go beyond the end of the index
+	oldidx := p.Index()
+	newindex, err = p.MoveIndex(p.Amount() + 1)
 	if err == nil {
 		t.Error("Expected an error moving index beyond end of permutations")
+	}
+	if oldidx != newindex {
+		t.Errorf("Index should not have moved from %d, to: %d\n", oldidx, newindex)
 	}
 
 	// Test that an error occurs if we specify a negative index
 	newindex, err = p.MoveIndex(-1)
 	if err == nil {
 		t.Error("Expected an error moving index negative")
+	}
+	if oldidx != newindex {
+		t.Errorf("Index should not have moved from %d, to: %d\n", oldidx, newindex)
+	}
+}
+
+func Test_Amount(t *testing.T) {
+	testintdata := []int{1, 2}
+	p, err := NewPerm(testintdata, nil)
+	if err != nil {
+		t.Errorf("Error creating permutator: '%s'\n", err)
+	}
+
+	if p.Amount() != 2 { // 2!
+		t.Errorf("Incorrect value for Amount. Expected 2 was %d'\n", p.Amount())
+	}
+
+	testintdata = []int{1, 2, 3, 4}
+	p, err = NewPerm(testintdata, nil)
+	if err != nil {
+		t.Errorf("Error creating permutator: '%s'\n", err)
+	}
+
+	if p.Amount() != 24 { // 4!
+		t.Errorf("Incorrect value for Amount. Expected 24 was %d'\n", p.Amount())
+	}
+
+	testintdata = []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+	p, err = NewPerm(testintdata, nil)
+	if err != nil {
+		t.Errorf("Error creating permutator: '%s'\n", err)
+	}
+
+	if p.Amount() != 3628800 { // 10!
+		t.Errorf("Incorrect value for Amount. Expected 3628800 was %d'\n", p.Amount())
 	}
 }

--- a/permutor_test.go
+++ b/permutor_test.go
@@ -52,7 +52,7 @@ func TestValueIsCopy(t *testing.T) {
 	for i, elem := range orig {
 		if p.value.Index(i).Int() != int64(elem) {
 			t.Errorf("Element mismatch: orig[%d] = %d; p.value[%d] = %d\n",
-				orig[i], p.value.Index(i).Int())
+				i, orig[i], i, p.value.Index(i).Int())
 		}
 	}
 
@@ -64,7 +64,7 @@ func TestValueIsCopy(t *testing.T) {
 	for i, elem := range orig {
 		if p.value.Index(i).Int() != int64(elem/2) {
 			t.Errorf("Element mismatch: orig[%d] = %d; p.value[%d] = %d\n",
-				orig[i], p.value.Index(i).Int())
+				i, orig[i], i, p.value.Index(i).Int())
 		}
 	}
 }


### PR DESCRIPTION
Added:

- MoveIndex function to allow the index to be moved to a requested location within the permutation set (i.e. if you are processing a large set and need to stop and resume, etc.)
- Added Length function which returns the number of permutations within the set. This appears similar to the existing Left function - but the implementations differ. I suspect Left has other uses.
- Unit tests for MoveIndex

Updated:
- Corrected some issues with existing test cases (not compiling)